### PR TITLE
Use Alpine 3.1 as the base image for docker-dns-rest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM alpine:3.1
 MAINTAINER "Patrick Hensley <spaceboy@indirect.com>"
 COPY . /data
 RUN /data/bootstrap
+EXPOSE 80
 ENTRYPOINT ["/data/docker_dnsrest"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:2.7-onbuild
+FROM alpine:3.1
 MAINTAINER "Patrick Hensley <spaceboy@indirect.com>"
-ENTRYPOINT ["./docker_dnsrest"]
+COPY . /data
+RUN /data/bootstrap
+ENTRYPOINT ["/data/docker_dnsrest"]
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ Usage
 -----
 
 
-First, start docker-dns-rest container:
+First, start docker-dns-rest container. The docker-dns-rest container listens
+on port 80 by default, so depending on how you run Docker you may need to map
+a host port:
 
-    % docker run -d -v /var/run/docker.sock:/docker.sock --name dns \
+    % docker run -d -p 5080:80 -v /var/run/docker.sock:/docker.sock --name dns \
         phensley/docker-dns-rest --verbose 
 
 Tail the logs:
@@ -44,7 +46,7 @@ the container name `www`:
 
     % curl -X PUT \
         -d '{"domains": ["*.example.com", "www.staging.internal.com"]}' \
-        http://172.17.0.2:5080/container/name/www
+        http://172.17.0.2:80/container/name/www
     {"code": 0}
 
 Now, start up a container with that name:

--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+PY=2.7.9-r0
+apk add --update python=$PY python-dev=$PY gcc libgcc libc-dev py-pip libev
+pip install -r /data/requirements.txt
+apk del python-dev gcc libgcc libc-dev py-pip libev
+rm -rf /tmp/*
+rm -rf /var/cache/apk/*
+

--- a/docker_dnsrest
+++ b/docker_dnsrest
@@ -30,9 +30,10 @@ from gevent.wsgi import WSGIServer
 
 PROCESS = 'dnsrest'
 DOCKER_SOCK = 'unix:///docker.sock'
+DOCKER_VERSION = '1.14'
 DNS_BINDADDR = '0.0.0.0:53'
 DNS_RESOLVER = ['8.8.8.8']
-REST_BINDADDR = '0.0.0.0:5080'
+REST_BINDADDR = '0.0.0.0:80'
 EPILOG = '<tbd>'
 
 
@@ -95,7 +96,7 @@ def main():
     for signum in (signal.SIGTERM, signal.SIGINT):
         gevent.signal(signum, stop, api, dns)
 
-    client = docker.Client(args.docker)
+    client = docker.Client(args.docker, version=DOCKER_VERSION)
     monitor = DockerMonitor(client, registry)
     gevent.wait([gevent.spawn(monitor.run)])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 dnslib
-docker-py
+docker-py>=0.5.3
 falcon
 gevent
 


### PR DESCRIPTION
Addressing issue #1, this change produces a ~47MB image versus ~900MB for the official Docker `python:2.7`-derived image.   It also switches the default port to 80 and sets the API and client versions for Docker.
