### PR TITLE
prevent container crashes by workaround for new events, ignoring those without id

### DIFF
--- a/dnsrest/monitor.py
+++ b/dnsrest/monitor.py
@@ -39,18 +39,21 @@ class DockerMonitor(object):
         # read the docker event stream and update the name table
         for raw in events:
             evt = json.loads(raw)
-            cid = evt['id']
-            status = evt['status']
-            if status in ('start', 'die'):
-                try:
-                    rec = self._inspect(cid)
-                    if rec:
-                        if status == 'start':
-                            self._registry.activate(rec)
-                        else:
-                            self._registry.deactivate(rec)
-                except Exception, e:
-                    print str(e)
+            if 'id' in evt:
+                cid = evt['id']
+                status = evt['status']
+                if status in ('start', 'die'):
+                    try:
+                        rec = self._inspect(cid)
+                        if rec:
+                            if status == 'start':
+                                self._registry.activate(rec)
+                            else:
+                                self._registry.deactivate(rec)
+                    except Exception, e:
+                        print str(e)
+            else:
+                print "Skipped event: " + str(evt)
 
     def _inspect(self, cid):
         # get full details on this container from docker


### PR DESCRIPTION
This PR would handle #9, but it is just a workaround. I can't see if those events which are skipped by the patch would be of relevance for the intended use case. 
In fact I'm not using the auto-registration of containers in DNS but only rely on the possibility to inject DNS entries via REST calls. 
