### PR TITLE
Fix handling of unresolved domain name which is not in the mapping list

### DIFF
--- a/dnsrest/namesrv.py
+++ b/dnsrest/namesrv.py
@@ -5,7 +5,7 @@ from dnslib import A, DNSHeader, DNSLabel, DNSRecord, QTYPE, RR
 from gevent import socket
 from gevent.server import DatagramServer
 from gevent.resolver_ares import Resolver
-
+from dnsrest.logger import log
 
 DNS_RESOLVER_TIMEOUT = 3.0
 
@@ -26,16 +26,21 @@ class DnsServer(DatagramServer):
         self._registry = registry
         self._resolver = None
         if dns_servers:
-            self._resolver = Resolver(servers=dns_servers,
-                timeout=DNS_RESOLVER_TIMEOUT, tries=1)
+            self._resolver = Resolver(servers=dns_servers, timeout=DNS_RESOLVER_TIMEOUT, tries=1)
 
     def handle(self, data, peer):
         rec = DNSRecord.parse(data)
         addr = None
         if rec.q.qtype in (QTYPE.A, QTYPE.AAAA):
+            log.debug('Quering DNS')
             addr = self._registry.resolve(rec.q.qname.idna())
             if not addr:
-                addr = self._resolve('.'.join(str(rec.q.qname.label)))
+                strArr = []
+                for l in rec.q.qname.label:
+                    strArr.append(str(l,'utf-8'))
+                domainName = '.'.join(strArr)
+                addr = self._resolve(domainName)
+        log.debug('Sending request to %s', addr)
         self.socket.sendto(self._reply(rec, addr), peer)
 
     def _reply(self, rec, addrs=None):
@@ -49,11 +54,13 @@ class DnsServer(DatagramServer):
         return reply.pack()
 
     def _resolve(self, name):
+        log.debug('resolve name=%s', name)
         if not self._resolver:
             return None
         try:
             return self._resolver.gethostbyname(name)
         except socket.gaierror as e:
+            log.debug('Host by name could not be resolved')
             msg = str(e)
             if not contains(msg, 'ETIMEOUT', 'ENOTFOUND'):
                 print(msg)

--- a/dnsrest/registry.py
+++ b/dnsrest/registry.py
@@ -104,6 +104,7 @@ class Registry(object):
 
     def resolve(self, name):
         'Resolves the address for this name, if any'
+        log.debug('Resolve %s', name)
         with self._lock:
             res = self._domains.get(name)
             if res:


### PR DESCRIPTION
With the bump to python 3.6 the domain name to resolve externally did not get joined in the correct way due to a different semantics in the join method from python 2.

Added also a few more debug outputs